### PR TITLE
【Fixed】rails generateコマンド実行時にhelper,assetsファイルを作成しないようにした

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,8 @@ module Achieve
     config.action_view.field_error_proc = proc { |html_tag, _| html_tag }
 
     config.generators do |g|
+      g.assets   false
+      g.helper   false
       g.test_framework :rspec,
         fixtures: true,
         view_specs: false,


### PR DESCRIPTION
#1 

・rails generateコマンドを実行する際に、config/application.rbにhelper,assetsファイルの追加をしないコードを追記