### PR TITLE
【Fixed】'pry-rails'と'better_errors'、'binding_of_caller'をgemのdevelopment配下に設置

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,9 +39,6 @@ group :development, :test do
   # Access an IRB console on exception pages or by using <%= console %> in views
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
-
-  gem 'pry-rails'
-
   gem 'capistrano', '3.6.0'
   gem 'capistrano-bundler'
   gem 'capistrano-rails'
@@ -57,6 +54,9 @@ gem 'jquery-turbolinks'
 
 
 group :development do
+  gem 'pry-rails'
+  gem 'better_errors'
+  gem 'binding_of_caller'
   gem 'letter_opener_web'
   gem 'web-console', '~> 2.0'
   gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,10 @@ GEM
       sshkit (>= 1.6.1, != 1.7.0)
     arel (6.0.3)
     bcrypt (3.1.11)
+    better_errors (2.1.1)
+      coderay (>= 1.0.0)
+      erubis (>= 2.6.6)
+      rack (>= 0.9.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
@@ -494,6 +498,7 @@ PLATFORMS
 
 DEPENDENCIES
   activeresource
+  better_errors
   binding_of_caller
   byebug
   cancan

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -4,6 +4,7 @@ class BlogsController < ApplicationController
 
   def index
     @blogs = Blog.all
+    raise
   end
 
 


### PR DESCRIPTION
Gemfile内
------------------------- 
 group :development do
  gem 'pry-rails'
  gem 'better_errors'
  gem 'binding_of_caller'
.
.
.
end